### PR TITLE
Don't store anything permanently on jupyterlite

### DIFF
--- a/jupyterlite-config/jupyter-lite.json
+++ b/jupyterlite-config/jupyter-lite.json
@@ -1,0 +1,8 @@
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "enableMemoryStorage": true,
+    "settingsStorageDrivers": ["memoryStorageDriver"],
+    "contentsStorageDrivers": ["memoryStorageDriver"]
+  }
+}


### PR DESCRIPTION
The memory storage driver allows us to have a brand new jupyterlite instance for each notebook, without having to store anything in the browser. Without this, we constantly end up with 'are you sure you wanna overwrite this file?' prompts.

Ref https://github.com/notebook-sharing-space/nbss/issues/40