### PR TITLE
Update for newer fastapi

### DIFF
--- a/nbss/app.py
+++ b/nbss/app.py
@@ -49,7 +49,6 @@ default_filters["clean_html"] = clean_html
 templates = Jinja2Templates(directory=os.path.join(BASE_PATH, "templates"))
 
 app = FastAPI(
-    root_path="/",
     title="nbss",
     description="fastest way to publish your notebooks on the web",
     openapi_tags=[


### PR DESCRIPTION
Apparently newer versions of fastapi don't like
root_path being explicitly set like this, and will just redirect the user to // from / and kinda fail.

Also will teach me to use requirements.in vs
requirements.txt