### PR TITLE
Make 'Open in JupyterLite' a Link

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -112,12 +112,11 @@ const ContentHeader = ({ filename, notebookId, notebookFormat, iframeRef, hasFra
                 </IconButton>
                 <Button
                     size="sm"
-                    display="inline-block"
                     marginLeft={-4}
                     colorScheme='orange'
-                    onClick={() => {
-                        window.location.href = makeJupyterLiteLink(notebookId, filename);
-                    }}
+                    as={Link}
+                    href={makeJupyterLiteLink(notebookId, filename)}
+                    _hover={{ textDecoration: 'none' }}
                 >
                     Open in JupyterLite
                 </Button>


### PR DESCRIPTION
This allows users to right click and copy the URL, and send it to people if they so wish.